### PR TITLE
[#849551] fixes Compatiblity to TYPO3 8.6

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,7 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+/* moved from ext_tables.php to here : Configuration/TCA/Overrides/ tt_content or sys_template if TYPO 8.7 */
+if (TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger( '8.7' ) ) {
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('frsupersized', 'Configuration/TypoScript', 'Supersized');
+}

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,25 @@
+<?php
+defined('TYPO3_MODE') or die();
+$_EXTKEY = 'frsupersized' ;
+
+
+/* moved from ext_tables.php to here : Configuration/TCA/Overrides/ tt_content or sys_template if TYPO3 8.7 */
+if (TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger( '8.7' ) ) {
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+        'FFREWER.' . $_EXTKEY,
+        'Pi1',
+        'Supersized'
+    );
+
+    $extensionName = \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($_EXTKEY);
+    $pluginSignature = strtolower($extensionName) . '_pi1';
+
+    // TYPO3 8.7. changed from $TCA[.. to $GLOBALS['TCA']
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:' . $_EXTKEY . '/Configuration/FlexForms/flexform_supersized.xml');
+
+    // TYPO3 8.7. changed from $TCA[.. to $GLOBALS['TCA']
+// eliminates the fields Plugin Mode & Record Storage Page on tab Behavior
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY . '_pi1'] = 'layout,select_key, pages,recursive';
+
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,6 @@
 <?php
 if (!defined ('TYPO3_MODE')) 	die ('Access denied.');
+$_EXTKEY = 'frsupersized' ;
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
 	'FFREWER.' . $_EXTKEY,

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,22 +1,30 @@
 <?php
 if (!defined ('TYPO3_MODE')) die ('Access denied.');
 
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-	'FFREWER.' . $_EXTKEY,
-	'Pi1',
-	'Supersized'
-);
+/* moved to Configuration/TCA/Overrides/ tt_content or sys_template if TYPO3 8.7 */
+if (TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) < TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger( '8.7' ) ) {
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Supersized');
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+        'FFREWER.' . $_EXTKEY,
+        'Pi1',
+        'Supersized'
+    );
 
-$extensionName = \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($_EXTKEY);
-$pluginSignature = strtolower($extensionName) . '_pi1';
-$TCA['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:' . $_EXTKEY . '/Configuration/FlexForms/flexform_supersized.xml');
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Supersized');
+
+    $extensionName = \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($_EXTKEY);
+    $pluginSignature = strtolower($extensionName) . '_pi1';
+    // does this work in TYPO3 7.6 ? should be $GLOBALS ??
+    $TCA['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:' . $_EXTKEY . '/Configuration/FlexForms/flexform_supersized.xml');
 
 
 // eliminates the fields Plugin Mode & Record Storage Page on tab Behavior
-$TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_pi1']  ='layout,select_key, pages,recursive';
+    $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_pi1']  ='layout,select_key, pages,recursive';
+
+}
+
+
 
 if (TYPO3_MODE == 'BE') {
 	// add wizicon to 'add content element'


### PR DESCRIPTION
I tested my changes with 8.7, with many predefined Sliders frpm the in 6.2 database update.

I just needed to add the Configuration/TCA/Overrides/tt_content.php and sys_templates.php and copy the  content from ext_tables and adjust tehm a little bit. 

The orginal Settings in ext_tables.php are encapsulated in a typo3_branch condition. 
(i just checked for the LTS Version of TYPO3 8.7 !) 

and in the 2 New Files the settings are only included if branch >=  8.7

feel free to set this to <= 8.0 and not only the LTS Version ... 

**Only one Remark :** 
In ext_tables.php there are still two $tca['']   settings.  
i think also in 7.6 of typo3 these settings should be $GLOBALS['TCA'][''] ... like in 8.7. 

Feel free to adjust also this .. 
